### PR TITLE
Decoding with sampling

### DIFF
--- a/aevnmt/aevnmt_helper.py
+++ b/aevnmt/aevnmt_helper.py
@@ -5,7 +5,7 @@ from torch.distributions.normal import Normal
 
 from aevnmt.data import BucketingParallelDataLoader, PAD_TOKEN, SOS_TOKEN, EOS_TOKEN
 from aevnmt.data import create_batch, batch_to_sentences
-from aevnmt.components import RNNEncoder, beam_search, greedy_decode
+from aevnmt.components import RNNEncoder, beam_search, greedy_decode, ancestral_sample
 from aevnmt.models import AEVNMT, RNNLM
 from .train_utils import create_attention, create_decoder, attention_summary, compute_bleu
 
@@ -91,7 +91,7 @@ def validate(model, val_data, vocab_src, vocab_tgt, device, hparams, step, title
                                                   device, hparams)
 
     random_idx = np.random.choice(len(inputs))
-    print(f"direction = {title}\n" 
+    print(f"direction = {title}\n"
           f"validation perplexity = {val_ppl:,.2f}"
           f" -- validation NLL = {val_NLL:,.2f}"
           f" -- validation BLEU = {val_bleu:.2f}"
@@ -145,7 +145,14 @@ def translate(model, input_sentences, vocab_src, vocab_tgt, device, hparams, det
 
         encoder_outputs, encoder_final = model.encode(x_in, seq_len_x, z)
         hidden = model.init_decoder(encoder_outputs, encoder_final, z)
-        if hparams.beam_width <= 1:
+
+        if hparams.sample_decoding:
+            raw_hypothesis = ancestral_sample(model.decoder, model.tgt_embed,
+                                           model.generate, hidden,
+                                           encoder_outputs, encoder_final,
+                                           seq_mask_x, vocab_tgt[SOS_TOKEN], vocab_tgt[EOS_TOKEN],
+                                           vocab_tgt[PAD_TOKEN], hparams.max_decoding_length)
+        elif hparams.beam_width <= 1:
             raw_hypothesis = greedy_decode(model.decoder, model.tgt_embed,
                                            model.generate, hidden,
                                            encoder_outputs, encoder_final,
@@ -159,6 +166,7 @@ def translate(model, input_sentences, vocab_src, vocab_tgt, device, hparams, det
                                          vocab_tgt[PAD_TOKEN], hparams.beam_width,
                                          hparams.length_penalty_factor,
                                          hparams.max_decoding_length)
+
     hypothesis = batch_to_sentences(raw_hypothesis, vocab_tgt)
     return hypothesis
 

--- a/aevnmt/aevnmt_helper.py
+++ b/aevnmt/aevnmt_helper.py
@@ -5,7 +5,7 @@ from torch.distributions.normal import Normal
 
 from aevnmt.data import BucketingParallelDataLoader, PAD_TOKEN, SOS_TOKEN, EOS_TOKEN
 from aevnmt.data import create_batch, batch_to_sentences
-from aevnmt.components import RNNEncoder, beam_search, greedy_decode, ancestral_sample
+from aevnmt.components import RNNEncoder, beam_search, greedy_decode, sampling_decode
 from aevnmt.models import AEVNMT, RNNLM
 from .train_utils import create_attention, create_decoder, attention_summary, compute_bleu
 
@@ -147,7 +147,7 @@ def translate(model, input_sentences, vocab_src, vocab_tgt, device, hparams, det
         hidden = model.init_decoder(encoder_outputs, encoder_final, z)
 
         if hparams.sample_decoding:
-            raw_hypothesis = ancestral_sample(model.decoder, model.tgt_embed,
+            raw_hypothesis = sampling_decode(model.decoder, model.tgt_embed,
                                            model.generate, hidden,
                                            encoder_outputs, encoder_final,
                                            seq_mask_x, vocab_tgt[SOS_TOKEN], vocab_tgt[EOS_TOKEN],

--- a/aevnmt/components/__init__.py
+++ b/aevnmt/components/__init__.py
@@ -2,9 +2,9 @@ from .decoders import BahdanauDecoder, LuongDecoder, tile_rnn_hidden_for_decoder
 from .encoders import RNNEncoder
 from .utils import rnn_creation_fn, tile_rnn_hidden
 from .attention import BahdanauAttention, LuongAttention
-from .search import greedy_decode, ancestral_sample
+from .search import greedy_decode, sampling_decode, ancestral_sample
 from .beamsearch import beam_search
 
 __all__ = ["BahdanauDecoder", "LuongDecoder", "RNNEncoder", "rnn_creation_fn",
-          "BahdanauAttention", "LuongAttention", "greedy_decode", "beam_search",
+          "BahdanauAttention", "LuongAttention", "greedy_decode", "sampling_decode", "beam_search",
           "tile_rnn_hidden", "tile_rnn_hidden_for_decoder", "ancestral_sample"]

--- a/aevnmt/hparams/hparams.py
+++ b/aevnmt/hparams/hparams.py
@@ -52,6 +52,7 @@ options = {
                                   " greedy decoding", 2),
     "length_penalty_factor": (float, 1.0, False, "Length penalty factor (alpha) for"
                                                  " beam search decoding.", 2),
+    "sample_decoding": (bool, False, False, "When decoding, sample instead of searching for the translation with maximum probability.", 2),
 
     # Optimization hyperparameters
     "gen_optimizer": (str, "adam", False, "Optimizer for generative parameters (options: adam, amsgrad, adadelta, sgd)", 3),

--- a/aevnmt/nmt_helper.py
+++ b/aevnmt/nmt_helper.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from aevnmt.data import BucketingParallelDataLoader, PAD_TOKEN, SOS_TOKEN, EOS_TOKEN
 from aevnmt.data import create_batch, batch_to_sentences
-from aevnmt.components import RNNEncoder, beam_search, greedy_decode, ancestral_sample
+from aevnmt.components import RNNEncoder, beam_search, greedy_decode, sampling_decode, ancestral_sample
 from aevnmt.models import ConditionalNMT
 from .train_utils import create_attention, create_decoder, attention_summary, compute_bleu
 
@@ -81,7 +81,7 @@ def translate(model, input_sentences, vocab_src, vocab_tgt, device, hparams):
         encoder_outputs, encoder_final = model.encode(x_in, seq_len_x)
         hidden = model.init_decoder(encoder_outputs, encoder_final)
         if hparams.sample_decoding:
-            raw_hypothesis = ancestral_sample(model.decoder, model.tgt_embed,
+            raw_hypothesis = sampling_decode(model.decoder, model.tgt_embed,
                                            model.generate, hidden,
                                            encoder_outputs, encoder_final,
                                            seq_mask_x, vocab_tgt[SOS_TOKEN], vocab_tgt[EOS_TOKEN],

--- a/aevnmt/nmt_helper.py
+++ b/aevnmt/nmt_helper.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from aevnmt.data import BucketingParallelDataLoader, PAD_TOKEN, SOS_TOKEN, EOS_TOKEN
 from aevnmt.data import create_batch, batch_to_sentences
-from aevnmt.components import RNNEncoder, beam_search, greedy_decode
+from aevnmt.components import RNNEncoder, beam_search, greedy_decode, ancestral_sample
 from aevnmt.models import ConditionalNMT
 from .train_utils import create_attention, create_decoder, attention_summary, compute_bleu
 
@@ -80,7 +80,13 @@ def translate(model, input_sentences, vocab_src, vocab_tgt, device, hparams):
         x_in, _, seq_mask_x, seq_len_x = create_batch(input_sentences, vocab_src, device)
         encoder_outputs, encoder_final = model.encode(x_in, seq_len_x)
         hidden = model.init_decoder(encoder_outputs, encoder_final)
-        if hparams.beam_width <= 1:
+        if hparams.sample_decoding:
+            raw_hypothesis = ancestral_sample(model.decoder, model.tgt_embed,
+                                           model.generate, hidden,
+                                           encoder_outputs, encoder_final,
+                                           seq_mask_x, vocab_tgt[SOS_TOKEN], vocab_tgt[EOS_TOKEN],
+                                           vocab_tgt[PAD_TOKEN], hparams.max_decoding_length)
+        elif hparams.beam_width <= 1:
             raw_hypothesis = greedy_decode(model.decoder, model.tgt_embed,
                                            model.generate, hidden,
                                            encoder_outputs, encoder_final,


### PR DESCRIPTION
Added an option to the command line that allows AEVNMT to sample from the next word probability distribution when decoding, rather than searching the sequence with maximum probability.

Used the existing "ancestral_sample" function, but had to add a .byte() call (see diffs). Otherwise, I got a runtime error, even when doing greedy (argmax) decoding instead of sampling.