### PR TITLE
Losses

### DIFF
--- a/aevnmt/components/__init__.py
+++ b/aevnmt/components/__init__.py
@@ -8,11 +8,11 @@ from .attention import BahdanauAttention, LuongAttention
 from .search import greedy_decode, sampling_decode, ancestral_sample
 from .beamsearch import beam_search
 from .lrschedulers import NoamScheduler
-from .loss_functions import label_smoothing_loss
-from .constraints import MDRConstraint, ConstraintOptimizer
+from .loss_functions import label_smoothing_loss, mmd_loss
+from .constraints import Constraint, ConstraintOptimizer
 
 __all__ = ["BahdanauDecoder", "LuongDecoder", "RNNEncoder", "rnn_creation_fn",
-          "BahdanauAttention", "LuongAttention", "greedy_decode", "sampling_decode", "beam_search",
-          "tile_rnn_hidden", "tile_rnn_hidden_for_decoder", "ancestral_sample", "TransformerEncoder", "TransformerDecoder",
-          "TransformerCompositionFunction", "NoamScheduler", "DecomposableAttentionEncoder", "DetachedEmbeddingLayer",
-          "label_smoothing_loss", "MDRConstraint", "ConstraintOptimizer"]
+           "BahdanauAttention", "LuongAttention", "greedy_decode", "sampling_decode", "beam_search",
+           "tile_rnn_hidden", "tile_rnn_hidden_for_decoder", "ancestral_sample", "TransformerEncoder", "TransformerDecoder",
+           "TransformerCompositionFunction", "NoamScheduler", "DecomposableAttentionEncoder", "DetachedEmbeddingLayer",
+           "label_smoothing_loss", "Constraint", "ConstraintOptimizer", "mmd_loss"]

--- a/aevnmt/components/loss_functions.py
+++ b/aevnmt/components/loss_functions.py
@@ -1,6 +1,26 @@
+import math
 import torch
+from torch import nn
 from torch.distributions import Categorical
+from torch_two_sample import MMDStatistic
 
+from .constraints import Constraint
+
+def log_likelihood_loss(likelihood, targets, ll_fn, pad_idx, label_smoothing=0.):
+    """
+    Returns the log-likelihood for the given likelihood and targets.
+
+    :param likelihood: likelihood Distribution.
+    :param targets: Targets for log_prob.
+    :param ll_fn: log_prob function, built-in Categorical log_prob is not used because there is no padding support.
+    :param pad_idx: idx of padding tokens in targets
+    :param label_smoothing: label smoothing factor between (0, 1), defaults to 0.
+    """
+    log_likelihood = ll_fn(likelihood, targets)
+    if label_smoothing > 0.:
+        smooth_loss = label_smoothing_loss(likelihood, targets, ignore_index=pad_idx)
+        log_likelihood = (1 - label_smoothing) * log_likelihood + label_smoothing * smooth_loss.sum(-1)
+    return log_likelihood
 
 def label_smoothing_loss(likelihood: Categorical, target, ignore_index=None):
     """
@@ -19,3 +39,203 @@ def label_smoothing_loss(likelihood: Categorical, target, ignore_index=None):
         smooth_loss.masked_fill_(pad_mask, 0.)
     smooth_loss = (smooth_loss / likelihood.probs.size(-1))
     return smooth_loss
+
+def mmd_loss(sample_1, sample_2):
+    """Computes an unbiased estimate of the MMD between two distributions given a set of samples from both.
+    
+    Source: https://github.com/tom-pelsmaeker/deep-generative-lm/blob/master/model/base_decoder.py
+    """
+    mmd = MMDStatistic(max(2, sample_1.shape[0]), max(2, sample_2.shape[0]))
+    if sample_1.shape[0] == 1:
+        return mmd(sample_1.expand(2, -1), sample_2.expand(2, -1), [1. / sample_1.shape[1]])
+    else:
+        return mmd(sample_1, sample_2, [1. / sample_1.shape[1]])
+
+
+class ELBOLoss:
+    def __init__(self, kl_weight=1., kl_annealing_steps=0., free_nats=0., mmd_weight=0., label_smoothing_x=0., label_smoothing_y=0.):
+        """
+        ELBOLoss implements both the ELBO [1] and InfoVAE loss for AEVNMT, by adding a mmd_weight to the regular ELBO.
+        It is advised to use InfoVAELoss with the InfoVAE, as this class determines the proper kl_weight and mmd_weight from the InfoVAE parameters.
+
+        [1] Kingma, Diederik P., and Max Welling. "Auto-encoding variational bayes."
+
+        :param kl_weight: Weight of the KL term, defaults to 1.
+        :param kl_annealing_steps: Adds a linear annealing schedule between [0, kl_weight], defaults to 0.
+        :param free_nats: Minimum KL value, the KL is not optimized if below this value, defaults to 0.
+        :param mmd_weight: Weight of the MMD term used with InfoVAE, defaults to 0.
+        :param label_smoothing_x: source language label smoothing, defaults to 0.
+        :param label_smoothing_y: target language label smoothing, defaults to 0.
+        """
+        self.kl_weight = kl_weight
+        self.kl_annealing_steps = kl_annealing_steps
+        self.free_nats = free_nats
+
+        self.mmd_weight = mmd_weight
+
+        self.label_smoothing_x = label_smoothing_x
+        self.label_smoothing_y = label_smoothing_y
+
+        self.num_samples = 1
+
+
+    def forward(self, tm_likelihood, lm_likelihood, targets_y, targets_x, qz, pz, sample_qz, step, model, reduction='mean'):
+        """
+        Computes an estimate of the negative evidence lower bound for the single sample of the latent
+        variable that was used to compute the categorical parameters, and the distributions qz
+        that the sample comes from.
+
+        :param tm_likelihood: Categorical distributions from LM with shape [B, Ty, Vy]
+        :param lm_likelihood: Categorical distributions from TM with shape [B, Tx, Vx]
+        :param targets_y: target labels target sentence [B, T_y]
+        :param targets_x: target labels source sentence [B, T_x]
+        :param qz: distribution that was used to sample the latent variable.
+        :param sample_z: The sample from q_z that was used to compute the likelihoods.
+        :param model: The model that contains log_prob definitions to compute the likelihoods.
+        :param reduction: what reduction to apply, none ([B]), mean ([]) or sum ([])
+        """
+        out_dict = dict()
+
+        tm_log_likelihood = log_likelihood_loss(tm_likelihood, targets_y,
+                                                model.translation_model.log_prob,
+                                                model.translation_model.tgt_embedder.padding_idx,
+                                                self.label_smoothing_y)
+        lm_log_likelihood = log_likelihood_loss(lm_likelihood, targets_x,
+                                                model.language_model.log_prob,
+                                                model.language_model.pad_idx,
+                                                self.label_smoothing_x)
+
+        # KL(q(z|x) || p(z))
+        KL = torch.distributions.kl_divergence(qz, pz)
+        raw_KL = KL * 1
+        if self.free_nats > 0:
+            KL = torch.clamp(KL, min=self.free_nats)
+        KL_weight = self.kl_weight
+        if self.kl_annealing_steps > 0:
+            KL_weight = min(KL_weight, (KL_weight / self.kl_annealing_steps) * step)
+
+        # ELBO and loss
+        elbo = tm_log_likelihood + lm_log_likelihood - KL * KL_weight
+        loss = - elbo
+
+        # MMD(q(z) || p(z))
+        if self.mmd_weight > 0.:
+            sample_pz = pz.sample([sample_qz.size(0)])
+            mmd = mmd_loss(sample_qz, sample_pz)
+            out_dict['MMD'] = mmd
+            # NOTE the loss is the negative ELBO, subtract MMD instead of adding.
+            loss = loss - mmd * self.mmd_weight
+
+        # Constraints
+        if 'MDR' in model.constraints:
+            constraint = model.constraints['MDR']
+            mdr_loss = constraint(KL)
+            loss = loss + mdr_loss
+            out_dict[f'constraints/multipliers/{constraint.name}'] = constraint.multiplier.detach()
+
+        if reduction == "mean":
+            out_dict['loss'] = loss.mean()
+        elif reduction == "sum":
+            out_dict['loss'] = loss.sum()
+        elif reduction == "none" or reduction is None:
+            out_dict['loss'] = loss
+        else:
+            raise Exception(f"Unknown reduction option {reduction}")
+        
+        out_dict['KL'] = KL.detach()
+        out_dict['raw_KL'] = raw_KL.detach()
+        out_dict['lm/main'] = lm_log_likelihood.detach()
+        out_dict['tm/main'] = tm_log_likelihood.detach()
+
+        return out_dict
+
+
+class InfoVAELoss(ELBOLoss):
+    def __init__(self, info_alpha=1., info_lambda=10., kl_annealing_steps=0., free_nats=0., mmd_weight=0., label_smoothing_x=0., label_smoothing_y=0.):
+        """
+        The InfoVAE objective [2]. As this loss is fully covered by the ELBO implementation,
+        the init only determines the correct KL and MMD weights from the InfoVAE parameters.
+
+        [2] Zhao, Shengjia, Jiaming Song, and Stefano Ermon. "Infovae: Information maximizing variational autoencoders."
+        """
+        self.info_alpha = info_alpha
+        self.info_lambda = info_lambda
+        kl_weight = 1 - info_alpha
+        mmd_weight = info_alpha + info_lambda - 1
+        super().__init__(kl_weight, kl_annealing_steps, free_nats, mmd_weight, label_smoothing_x, label_smoothing_y)
+
+
+class LagVAELoss:
+    def __init__(self, alpha, label_smoothing_x=0., label_smoothing_y=0.):
+        """
+        LagVAE Loss [3]. The bounds for the ELBO and MMD constraints are defined when the constraints are constructed, in aevnmt_helper.py.
+
+        [3] Zhao, Shengjia, Jiaming Song, and Stefano Ermon. "A lagrangian perspective on latent variable generative models."
+
+        :param alpha: The scaling parameter that determines which bound is optimized.
+        """
+        self.alpha = alpha
+        if alpha >= 0:
+            raise NotImplementedError(f"Minimizing the MI upper bound is not implemented (alpha = {alpha}).")
+
+        self.label_smoothing_x = label_smoothing_x
+        self.label_smoothing_y = label_smoothing_y
+
+        self.num_samples = 1
+
+    def forward(self, tm_likelihood, lm_likelihood, targets_y, targets_x, qz, pz, sample_qz, step, model, reduction='mean'):
+        raise NotImplementedError()
+
+
+class IWAELoss:
+    def __init__(self, num_samples, label_smoothing_x=0., label_smoothing_y=0.):
+        """
+        The Importance Weighted Autoencoder (IWAE) objective [4].
+
+        [4] Burda, Yuri, Roger Grosse, and Ruslan Salakhutdinov. "Importance weighted autoencoders."
+
+        :param num_samples: [description]
+        :type num_samples: [type]
+        :param label_smoothing_x: [description], defaults to 0.
+        :type label_smoothing_x: [type], optional
+        :param label_smoothing_y: [description], defaults to 0.
+        :type label_smoothing_y: [type], optional
+        """
+        self.num_samples = num_samples
+        self.label_smoothing_x = label_smoothing_x
+        self.label_smoothing_y = label_smoothing_y
+
+    def forward(self, tm_likelihood, lm_likelihood, targets_y, targets_x, qz, pz, sample_qz, step, model, reduction='mean'):
+        out_dict = dict()
+        batch_size = sample_qz.shape[0] / self.num_samples
+
+        # log probabilities [num_samples, batch_size]
+        ll_py = log_likelihood_loss(tm_likelihood, targets_y,
+                                    model.translation_model.log_prob,
+                                    model.translation_model.tgt_embedder.padding_idx,
+                                    self.label_smoothing_y)
+        ll_py = ll_py.view(self.num_samples, batch_size)
+        ll_px = log_likelihood_loss(lm_likelihood, targets_x,
+                                    .language_model.log_prob,
+                                    .language_model.pad_idx,
+                                    self.label_smoothing_x)
+        ll_px = ll_px.view(self.num_samples, batch_size)
+
+        sample_qz = sample_qz.view(self.num_samples, batch_size, -1)
+        logprob_qz = qz.log_prob(sample_qz).sum(-1)
+        logprob_pz = pz.log_prob(sample_qz).sum(-1)
+
+        # Importance weights
+        log_w = ll_px + ll_py + logprob_pz - logprob_qz
+        raw_loss = torch.logsumexp(log_w, dim=0) - math.log(self.num_samples)
+
+        # Loss with normalized importance weights
+        w_norm = torch.softmax(log_w, dim=0)
+        loss = torch.sum(w_norm.detach() * log_w, dim=0)
+
+        out_dict['loss'] = loss
+        out_dict['raw_loss'] = raw_loss.detach()
+        out_dict['tm/main'] = torch.logsumexp(ll_py, dim=0).detach()
+        out_dict['lm/main'] = torch.logsumexp(ll_px, dim=0).detach()
+
+        return out_dict

--- a/aevnmt/hparams/args.py
+++ b/aevnmt/hparams/args.py
@@ -155,6 +155,7 @@ opt_args = {
     # General
     "num_epochs": (int, 1, False, "The number of epochs to train the model for."),
     "batch_size": (int, 64, False, "The batch size."),
+    "update_freq": (int, 1, False, "Accumulate gradients and update model parameters every N steps."),
     "print_every": (int, 100, False, "Print training statistics every x steps."),
     "max_gradient_norm": (float, 5.0, False, "The maximum gradient norm to clip the"
                                              " gradients to, to disable"
@@ -227,8 +228,8 @@ loss_args = {
     "loss.InfoVAE.alpha": (float, 0., False, "Relative weight of the KL and MMD terms."),
     "loss.InfoVAE.lamb": (float, 0., False, "Scaling of the InfoVAE MMD term."),
 
-    "loss.LagVAE.min_elbo": (float, 0., False, "LagVAE bound for KL(q(x, z) || p(x, z))"),
-    "loss.LagVAE.min_mmd": (float, 0., False, "LagVAE bound for MMD(q(z) || p(z))"),
+    "loss.LagVAE.max_elbo": (float, 0., False, "LagVAE bound for KL(q(x, z) || p(x, z))"),
+    "loss.LagVAE.max_mmd": (float, 0., False, "LagVAE bound for MMD(q(z) || p(z))"),
     "loss.LagVAE.alpha": (float, -1., False, "LagVAE parameter that specifies maximization/minimization of the mutual information bound."),
 
     "loss.IWAE.num_samples": (int, 10, False, "Number of MC estimate samples for the IWAE objective."),

--- a/aevnmt/hparams/args.py
+++ b/aevnmt/hparams/args.py
@@ -216,10 +216,29 @@ decoding_args = {
     "decoding.max_length": (int, 50, False, "Maximum decoding length"),
 }
 
-kl_args = {
-    "kl.free_nats": (float, 0., False, "KL = min(KL_free_nats, KL)"),
-    "kl.annealing_steps": (int, 0, False, "Amount of KL annealing steps (0...1)"),
-    "kl.mdr": (float, -1., False, "If positive adds a soft Lagrangian constraint for the KL term to minimally achieve the given value."),
+loss_args = {
+    "loss.type": (str, "ELBO", False, "Type of training objective. likelihood|ELBO|InfoVAE|LagVAE|IWVAE"),
+
+    "loss.ELBO.beta": (float, 1., False, "Weight of the ELBO KL term."),
+    "loss.ELBO.free_nats": (float, 0., False, "KL = min(free_nats, KL)"),
+    "loss.ELBO.kl_annealing_steps": (int, 0, False, "Amount of KL annealing steps (0...1)"),
+    "loss.ELBO.mdr": (float, 0., False, "Adds a minimum desired rate by putting a lagrangian constraint for the KL on the ELBO."),
+
+    "loss.InfoVAE.alpha": (float, 0., False, "Relative weight of the KL and MMD terms."),
+    "loss.InfoVAE.lamb": (float, 0., False, "Scaling of the InfoVAE MMD term."),
+
+    "loss.LagVAE.min_elbo": (float, 0., False, "LagVAE bound for KL(q(x, z) || p(x, z))"),
+    "loss.LagVAE.min_mmd": (float, 0., False, "LagVAE bound for MMD(q(z) || p(z))"),
+    "loss.LagVAE.alpha": (float, -1., False, "LagVAE parameter that specifies maximization/minimization of the mutual information bound."),
+
+    "loss.IWAE.num_samples": (int, 10, False, "Number of MC estimate samples for the IWAE objective."),
+
+    # "kl.weight": (float, 1., False, "Weight of the KL-divergence in the AEVNMT loss."),
+    # "kl.free_nats": (float, 0., False, "KL = min(KL_free_nats, KL)"),
+    # "kl.annealing_steps": (int, 0, False, "Amount of KL annealing steps (0...1)"),
+    # "loss.mdr": (float, 0., False, "Bound of th KL constraint, used when the value is larger than 0."),
+    # "loss.mmd_weight": (float, 0., False, "Weight of the MMD term in the AEVNMT loss."),
+    # "loss.mmd_constraint": (float, 0., False, "Bound of the MMD constraint, used when the value larger than 0.")
 }
 
 translation_args = {
@@ -255,7 +274,7 @@ arg_groups = {
     "Aux Losses": aux_args,
     "Optimization": opt_args,
     "Decoding": decoding_args,
-    "KL": kl_args,
+    "Loss": loss_args,
     "Translation": translation_args
 }
 

--- a/aevnmt/nmt_helper.py
+++ b/aevnmt/nmt_helper.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from aevnmt.data import BucketingParallelDataLoader, PAD_TOKEN, SOS_TOKEN, EOS_TOKEN
 from aevnmt.data import create_batch, batch_to_sentences
-from aevnmt.components import RNNEncoder, TransformerEncoder, beam_search, greedy_decode, sampling_decode, ancestral_sample
+from aevnmt.components import RNNEncoder, TransformerEncoder, beam_search, greedy_decode, sampling_decode, ancestral_sample, loss_functions
 from aevnmt.models import ConditionalNMT
 from aevnmt.models.generative import AttentionBasedTM, TransformerTM
 from .train_utils import create_encoder, create_attention, create_decoder, attention_summary, compute_bleu
@@ -49,6 +49,11 @@ def create_model(hparams, vocab_src, vocab_tgt):
 
     model = ConditionalNMT(translation_model)
     return model
+
+def create_loss(hparams):
+    if hparams.loss.type != "LL":
+        print(f"Warning: {hparams.loss.type} is an invalid loss type for NMT. Using log likelihood loss instead")
+    return loss_functions.LogLikelihoodLoss(label_smoothing=hparams.gen.tm.label_smoothing)
 
 def train_step(model, x_in, x_out, seq_mask_x, seq_len_x, noisy_x_in, y_in, y_out, seq_mask_y, seq_len_y, noisy_y_in,
                hparams, step, summary_writer=None):

--- a/aevnmt/train.py
+++ b/aevnmt/train.py
@@ -18,39 +18,32 @@ from aevnmt.data.utils import create_noisy_batch
 from aevnmt.models import initialize_model
 from aevnmt.models.parallel import ParallelWrapper, ParallelAEVNMT, aevnmt_train_parallel
 from aevnmt.opt_utils import construct_optimizers, lr_scheduler_step
-from aevnmt.trainers import AEVNMTTrainer
+from aevnmt.trainers import AEVNMTTrainer, NMTTrainer
 from aevnmt.components import loss_functions
-
-import warnings
-warnings.simplefilter(action='ignore', category=UserWarning)
 
 
 def create_model(hparams, vocab_src, vocab_tgt):
     if hparams.model.type == "cond_nmt":
         model = nmt_helper.create_model(hparams, vocab_src, vocab_tgt)
-        train_fn = nmt_helper.train_step
+        loss = nmt_helper.create_loss(hparams)
+        trainer = NMTTrainer(model, loss)
         validate_fn = nmt_helper.validate
         translate_fn = nmt_helper.translate
     elif hparams.model.type == "aevnmt":
         model = aevnmt_helper.create_model(hparams, vocab_src, vocab_tgt)
-        loss = aevnmt_helper.create_loss(model, hparams)
+        loss = aevnmt_helper.create_loss(hparams)
         trainer = AEVNMTTrainer(model, loss)
-        train_fn = trainer.step
         validate_fn = aevnmt_helper.validate
         translate_fn = aevnmt_helper.translate
     else:
         raise Exception(f"Unknown model_type: {hparams.model.type}")
 
-    return model, train_fn, validate_fn, translate_fn
+    return model, trainer, validate_fn, translate_fn
 
 
-def train(model, optimizers, lr_schedulers, training_data, val_data, vocab_src,
-          vocab_tgt, device, out_dir, train_step, validate, hparams):
+def train(trainer, optimizers, lr_schedulers, training_data, val_data, vocab_src,
+          vocab_tgt, device, out_dir, validate, hparams):
     """
-    :param train_step: function that performs a single training step and returns
-                       training loss. Takes as inputs: model, x_in, x_out,
-                       seq_mask_x, seq_len_x, y_in, y_out, seq_mask_y,
-                       seq_len_y, hparams, step.
     :param validate: function that performs validation and returns validation
                      BLEU, used for model selection. Takes as inputs: model,
                      val_data, vocab, device, hparams, step, summary_writer.
@@ -59,6 +52,8 @@ def train(model, optimizers, lr_schedulers, training_data, val_data, vocab_src,
                      summaries and write any validation metrics to the
                      standard out.
     """
+
+    model = trainer.model
 
     # Create a dataloader that buckets the batches.
     dl = DataLoader(training_data, batch_size=hparams.batch_size,
@@ -110,7 +105,7 @@ def train(model, optimizers, lr_schedulers, training_data, val_data, vocab_src,
             y_in, y_out, seq_mask_y, seq_len_y, noisy_y_in = create_noisy_batch(
                 sentences_y, vocab_tgt, device,
                 word_dropout=hparams.word_dropout)
-            return_dict = train_step(
+            return_dict = trainer.step(
                     x_in, x_out, seq_mask_x, seq_len_x, noisy_x_in,
                     y_in, y_out, seq_mask_y, seq_len_y, noisy_y_in,
                     step, summary_writer=summary_writer)
@@ -122,10 +117,12 @@ def train(model, optimizers, lr_schedulers, training_data, val_data, vocab_src,
                 # TODO: do we need separate norms?
                 nn.utils.clip_grad_norm_(model.parameters(),
                                          hparams.max_gradient_norm)
-            optimizers["gen"].step()
-            if "inf_z" in optimizers: optimizers["inf_z"].step()
-            if "lagrangian" in optimizers:
-                optimizers["lagrangian"].step()
+            if (step + 1) % hparams.update_freq == 0:
+                optimizers["gen"].step()
+                if "inf_z" in optimizers: 
+                    optimizers["inf_z"].step()
+                if "lagrangian" in optimizers:
+                    optimizers["lagrangian"].step()
             # Update statistics.
             num_tokens += (seq_len_x.sum() + seq_len_y.sum()).item()
             num_sentences += x_in.size(0)
@@ -169,10 +166,11 @@ def train(model, optimizers, lr_schedulers, training_data, val_data, vocab_src,
                 total_train_loss = 0.
                 num_sentences = 0
 
-            # Zero the gradient buffer.
-            optimizers["gen"].zero_grad()
-            if "inf_z" in optimizers: optimizers["inf_z"].zero_grad()
-            if "lagrangian" in optimizers: optimizers["lagrangian"].zero_grad()
+            if (step + 1) % hparams.update_freq == 0:
+                # Zero the gradient buffer every update_freq steps
+                optimizers["gen"].zero_grad()
+                if "inf_z" in optimizers: optimizers["inf_z"].zero_grad()
+                if "lagrangian" in optimizers: optimizers["lagrangian"].zero_grad()
 
             # Update the learning rate scheduler if needed.
             lr_scheduler_step(lr_schedulers, hparams)
@@ -226,16 +224,15 @@ def main():
     print(f"Validation data: {len(val_data):,} bilingual sentence pairs")
 
     # Create the language model and load it onto the GPU if set to do so.
-    model, train_fn, validate_fn, _ = create_model(hparams, vocab_src, vocab_tgt)
-    if hparams.data_parallel:
-        model = ParallelAEVNMT(model, hparams)
-        model = ParallelWrapper(model)
+    model, trainer, validate_fn, _ = create_model(hparams, vocab_src, vocab_tgt)
+
     optimizers, lr_schedulers = construct_optimizers(
         hparams,
         gen_parameters=model.generative_parameters(),
         inf_z_parameters=model.inference_parameters(),
         lagrangian_parameters=model.lagrangian_parameters())
     device = torch.device("cuda:0") if hparams.use_gpu else torch.device("cpu")
+
     model = model.to(device)
 
     # Print information about the model.
@@ -272,8 +269,8 @@ def main():
     # Train the model.
     print("\n==== Starting training")
     print(f"Using device: {device}\n")
-    train(model, optimizers, lr_schedulers, train_data, val_data, vocab_src,
-          vocab_tgt, device, out_dir, train_fn, validate_fn, hparams)
+    train(trainer, optimizers, lr_schedulers, train_data, val_data, vocab_src,
+          vocab_tgt, device, out_dir, validate_fn, hparams)
 
 if __name__ == "__main__":
     main()

--- a/aevnmt/trainers.py
+++ b/aevnmt/trainers.py
@@ -23,6 +23,7 @@ class AEVNMTTrainer:
             return tensor_exp
 
     def _flatten_samples(self, tensor):
+        """[num_samples, B, ...] -> [num_samples * B, ...]"""
         if tensor is not None:
             return tensor.view(tensor.shape[0] * tensor.shape[1], *tensor.shape[2:])
 
@@ -76,6 +77,6 @@ class NMTTrainer:
 
     def step(self, x_in, x_out, seq_mask_x, seq_len_x, noisy_x_in, y_in, y_out,
              seq_mask_y, seq_len_y, noisy_y_in, step, summary_writer=None):
-        likelihood, _ = model(noisy_x_in, seq_mask_x, seq_len_x, noisy_y_in)
-        loss_dict = self.loss(likelihood, y_out, reduction="mean")
+        likelihood, _ = self.model(noisy_x_in, seq_mask_x, seq_len_x, noisy_y_in)
+        loss_dict = self.loss(likelihood, y_out, self.model, reduction="mean")
         return loss_dict

--- a/aevnmt/trainers.py
+++ b/aevnmt/trainers.py
@@ -1,0 +1,80 @@
+import torch
+from torch.distributions import Categorical
+from aevnmt.dist import get_named_params
+
+class AEVNMTTrainer:
+    def __init__(self, model, loss, histogram_every=100):
+        self.model = model
+        self.loss = loss
+        self.histogram_every = histogram_every
+
+    def _repeat_over_samples(self, tensor, num_samples, flatten=True):
+        """
+        Repeats given tensor with shape [B, ...] over num_samples, the resulting shape is:
+        [num_samples * B, ...] if flatten,
+        [num_samples, B, ...] otherwise.
+
+        A flattened tensor can be unflattened with self._unflatten_samples.
+        """
+        if tensor is not None:
+            tensor_exp = tensor.unsqueeze(0).repeat(num_samples, *[1]*len(tensor.shape))
+            if flatten:
+                tensor_exp = self._flatten_samples(tensor_exp)
+            return tensor_exp
+
+    def _flatten_samples(self, tensor):
+        if tensor is not None:
+            return tensor.view(tensor.shape[0] * tensor.shape[1], *tensor.shape[2:])
+
+    def _unflatten_samples(self, tensor, num_samples):
+        if tensor is not None:
+            return tensor.view(num_samples, -1, *tensor.shape[1:])
+
+    def step(self, x_in, x_out, seq_mask_x, seq_len_x, noisy_x_in, y_in, y_out,
+             seq_mask_y, seq_len_y, noisy_y_in, step, summary_writer=None):
+        q_z = self.model.approximate_posterior(x_in, seq_mask_x, seq_len_x, y_in, seq_mask_y, seq_len_y)
+        p_z = self.model.prior()
+
+        if self.loss.num_samples == 1:
+            z = q_z.rsample()
+        else:
+            z = q_z.rsample([self.loss.num_samples])
+            z = self._flatten_samples(z) # [K * B, ...]
+
+            # Expand required inputs to [K * B, ...]
+            noisy_x_in = self._repeat_over_samples(noisy_x_in, self.loss.num_samples, flatten=True)
+            noisy_y_in = self._repeat_over_samples(noisy_y_in, self.loss.num_samples, flatten=True)
+            seq_mask_x = self._repeat_over_samples(seq_mask_x, self.loss.num_samples, flatten=True)
+            seq_len_x = self._repeat_over_samples(seq_len_x, self.loss.num_samples, flatten=True)
+
+            # Expand targets
+            x_out = self._repeat_over_samples(x_out, self.loss.num_samples, flatten=True)
+            y_out = self._repeat_over_samples(y_out, self.loss.num_samples, flatten=True)
+
+        tm_likelihood, lm_likelihood = self.model(noisy_x_in, seq_mask_x, seq_len_x, noisy_y_in, z)
+
+        loss_dict = self.loss(tm_likelihood, lm_likelihood, y_out, x_out, q_z, p_z, z, step, self.model, reduction='mean')
+
+        if summary_writer and step % self.histogram_every == 0:
+            # generate histograms for the posterior and prior
+            summary_writer.add_histogram("posterior/z", z, step)
+            for param_name, param_value in get_named_params(q_z):
+                summary_writer.add_histogram("posterior/%s" % param_name, param_value, step)
+            prior_sample = p_z.sample(torch.Size([z.size(0)]))
+            summary_writer.add_histogram("prior/z", prior_sample, step)
+            for param_name, param_value in get_named_params(p_z):
+                summary_writer.add_histogram("prior/%s" % param_name, param_value, step)
+
+        return loss_dict
+
+
+class NMTTrainer:
+    def __init__(self, model, loss):
+        self.model = model
+        self.loss = loss
+
+    def step(self, x_in, x_out, seq_mask_x, seq_len_x, noisy_x_in, y_in, y_out,
+             seq_mask_y, seq_len_y, noisy_y_in, step, summary_writer=None):
+        likelihood, _ = model(noisy_x_in, seq_mask_x, seq_len_x, noisy_y_in)
+        loss_dict = self.loss(likelihood, y_out, reduction="mean")
+        return loss_dict

--- a/aevnmt/trainers.py
+++ b/aevnmt/trainers.py
@@ -51,7 +51,8 @@ class AEVNMTTrainer:
             x_out = self._repeat_over_samples(x_out, self.loss.num_samples, flatten=True)
             y_out = self._repeat_over_samples(y_out, self.loss.num_samples, flatten=True)
 
-        tm_likelihood, lm_likelihood = self.model(noisy_x_in, seq_mask_x, seq_len_x, noisy_y_in, z)
+        # TODO aux likelihoods are not used in the new Loss functions.
+        tm_likelihood, lm_likelihood, _, _, _ = self.model(noisy_x_in, seq_mask_x, seq_len_x, noisy_y_in, z)
 
         loss_dict = self.loss(tm_likelihood, lm_likelihood, y_out, x_out, q_z, p_z, z, step, self.model, reduction='mean')
 

--- a/aevnmt/translate.py
+++ b/aevnmt/translate.py
@@ -121,6 +121,7 @@ class TranslationEngine:
             print(f"Restoring model selected wrt {self.hparams.criterion} from {self.model_checkpoint}", file=sys.stderr)
 
         model, _, _, translate_fn = create_model(self.hparams, self.vocab_src, self.vocab_tgt)
+        
         if self.hparams.use_gpu:
             model.load_state_dict(torch.load(self.model_checkpoint))
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-torch==1.2.0
+torch
 numpy
 tensorboardX==1.6
 Pillow


### PR DESCRIPTION
This PR adds new loss functions for the AEVNMT model, and moves losses into a separate module.
A new Trainer class combines a loss function and model.

- Added InfoVAE, LagVAE, IWAE losses, along with required components.
- Moved the NMT loss to LogLikelihoodLoss
- Moved the AEVNMT to ELBOLoss
- Added AEVNMTTrainer, which performs the old train_step functions, along with a train step with multiple samples from q(z|x) for IWAE.
- Added NMTTrainer, which does the same as the old train_step.
- Added support for aggregating gradients over multiple train steps.